### PR TITLE
Faults refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 A FUSE file system with an internal dedicated page cache that only flushes data if explicitly requested by the application. This is useful for simulating power failures and losing all unsynced data.
 
-> **Note**: The main branch is probably unstable and with not fully-tested features, so we recommend using one of [existing releases](https://github.com/dsrhaslab/lazyfs/releases) already created.
+<!--- > **Note**: The main branch is probably unstable and with not fully-tested features, so we recommend using one of [existing releases](https://github.com/dsrhaslab/lazyfs/releases) already created. -->
 
 ## Installation
 
@@ -106,7 +106,7 @@ I recommend following the `simple` cache configuration (indicating the cache siz
 **Optionally**, users can specify a set of predefined `injection` faults before LazyFS starts running. These faults are introduced as additional features, namely:
 
 -   **torn-seq**: This fault type is used when a sequence of system calls, targeting a single file, is executed consecutively without an intervening `fsync`. *In the example*, during the second group of consecutive writes (the group number is defined by the parameter `occurrence`), to the file "output.txt", the first and fourth writes will be persisted to disk (the writes to be persisted are defined by the parameter `persist`). After the fourth write (the last in the `persist` vector), LazyFS will crash itself.
--   **torn-op**: This fault type involves dividing a write system call into smaller portions, with some of these portions being persisted while others are not. In the example, the fifth write issued (the number of the write is defined by the parameter `occurrence`) to the file "output1.txt" will be divided into three equal parts if the `parts` parameter is used, or into customizable-sized parts if the `parts_bytes` parameter is defined. In the commented code, there's an example of using `parts_bytes`, where the write will be torn into three parts: the first with 4096 bytes, the second with 3600 bytes, and the last with 1200 bytes. The `persist` vector determines which parts will be persisted. After the persistence of these parts, LazyFS will crash.
+-   **torn-op**: This fault type involves dividing a write system call into smaller parts, with some of these parts being persisted while others are not. In the example, the fifth write issued (the number of the write is defined by the parameter `occurrence`) to the file "output1.txt" will be divided into three equal parts if the `parts` parameter is used, or into customizable-sized parts if the `parts_bytes` parameter is defined. In the commented code, there's an example of using `parts_bytes`, where the write will be torn into three parts: the first with 4096 bytes, the second with 3600 bytes, and the last with 1200 bytes. The `persist` vector determines which parts will be persisted. After the persistence of these parts, LazyFS will crash.
 
 Other parameters:
 

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ log_all_operations=false
 logfile="/tmp/lazyfs.log"
 
 [[injection]]
-type="reorder"
+type="torn-seq"
 op="write"
 file="output.txt"
 persist=[1,4]
 occurrence=2
 
 [[injection]]
-type="split_write"
+type="torn-op"
 file="output1.txt"
 occurrence=5
 parts=3 #or parts_bytes=[4096,3600,1260]
@@ -105,8 +105,8 @@ I recommend following the `simple` cache configuration (indicating the cache siz
 
 **Optionally**, users can specify a set of predefined `injection` faults before LazyFS starts running. These faults are introduced as additional features, namely:
 
--   **reorder**: This fault type is used when a sequence of system calls, targeting a single file, is executed consecutively without an intervening `fsync`. *In the example*, during the second group of consecutive writes (the group number is defined by the parameter `occurrence`), to the file "output.txt", the first and fourth writes will be persisted to disk (the writes to be persisted are defined by the parameter `persist`). After the fourth write (the last in the `persist` vector), LazyFS will crash itself.
--   **split_write**: This fault type involves dividing a write system call into smaller portions, with some of these portions being persisted while others are not. In the example, the fifth write issued (the number of the write is defined by the parameter `occurrence`) to the file "output1.txt" will be divided into three equal parts if the `parts` parameter is used, or into customizable-sized parts if the `parts_bytes` parameter is defined. In the commented code, there's an example of using `parts_bytes`, where the write will be split into three parts: the first with 4096 bytes, the second with 3600 bytes, and the last with 1200 bytes. The `persist` vector determines which parts will be persisted. After the persistence of these parts, LazyFS will crash.
+-   **torn-seq**: This fault type is used when a sequence of system calls, targeting a single file, is executed consecutively without an intervening `fsync`. *In the example*, during the second group of consecutive writes (the group number is defined by the parameter `occurrence`), to the file "output.txt", the first and fourth writes will be persisted to disk (the writes to be persisted are defined by the parameter `persist`). After the fourth write (the last in the `persist` vector), LazyFS will crash itself.
+-   **torn-op**: This fault type involves dividing a write system call into smaller portions, with some of these portions being persisted while others are not. In the example, the fifth write issued (the number of the write is defined by the parameter `occurrence`) to the file "output1.txt" will be divided into three equal parts if the `parts` parameter is used, or into customizable-sized parts if the `parts_bytes` parameter is defined. In the commented code, there's an example of using `parts_bytes`, where the write will be torn into three parts: the first with 4096 bytes, the second with 3600 bytes, and the last with 1200 bytes. The `persist` vector determines which parts will be persisted. After the persistence of these parts, LazyFS will crash.
 
 Other parameters:
 

--- a/lazyfs/src/lazyfs.cpp
+++ b/lazyfs/src/lazyfs.cpp
@@ -158,9 +158,9 @@ void LazyFS::trigger_crash_fault (string opname,
 
                 if (fault_type == CRASH)
                     this_ ()->command_unsynced_data_report ("none");
-                else if (fault_type == SPLITWRITE) {
+                else if (fault_type == TORN_OP) {
                     this_ ()->command_unsynced_data_report (from_op_path);
-                } else if (fault_type == REORDER) {
+                } else if (fault_type == TORN_SEQ) {
                     this_ ()->command_unsynced_data_report (from_op_path);
                 }
 
@@ -1114,9 +1114,9 @@ int LazyFS::lfs_write (const char* path,
     bool crash_added = this_ () -> persist_write(path,buf,size,offset);
     if (!crash_added) { //At the moment only one fault type can be injected
         crash_added =  this_ () -> split_write(path,buf,size,offset);
-        fault_type = SPLITWRITE;
+        fault_type = TORN_OP;
     } else {
-        fault_type = REORDER; 
+        fault_type = TORN_SEQ; 
     }
 
     // res should be = actual bytes written as pwrite could fail...

--- a/libs/libpcache/include/cache/config/config.hpp
+++ b/libs/libpcache/include/cache/config/config.hpp
@@ -9,8 +9,8 @@
 
 #ifndef CACHE_CONFIG_HPP
 #define CACHE_CONFIG_HPP
-#define SPLITWRITE "split_write"
-#define REORDER "reorder"
+#define TORN_OP "torn-op"
+#define TORN_SEQ "torn-seq"
 #define CRASH "crash"
 
 #include <string>
@@ -53,7 +53,7 @@ class Fault {
 };
 
 /**
- * @brief Fault for splitting writes in smaller writes.
+ * @brief Fault for splitting writes in smaller writes and reordering them (torn-op fault).
 */
 class SplitWriteF : public Fault {
   public:
@@ -112,7 +112,7 @@ class SplitWriteF : public Fault {
 };
 
 /**
- * @brief Fault for reordering system calls.
+ * @brief Fault for reordering system calls (torn-seq fault).
 */
 class ReorderF : public Fault {
 
@@ -168,7 +168,7 @@ class Config {
 
   private:
     /**
-     * @brief Sets up cache paraments by specifying the total size in bytes and the number
+     * @brief Sets up cache parameters by specifying the total size in bytes and the number
      * of blocks per page. By using this version, a 4k block size is considered.
      *
      * @param prealloc_bytes The total size in bytes.
@@ -187,7 +187,7 @@ class Config {
 
   public:
     /**
-     * @brief Wheter to log filesystem operations to stdout
+     * @brief Whether to log filesystem operations to stdout
      *
      */
     bool log_all_operations = false;


### PR DESCRIPTION
Change the name of the configured faults from `reorder` to `torn-seq` and from `split_write` to `torn-op`. 