### PR TITLE
fix build workflow: update action versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,10 @@ jobs:
           LAZYFS_TEST_ROOT_DIR: "/tmp/lfs.root/"
         steps:
             - name: Check out repository code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v6
 
             - name: Set up cache
-              uses: actions/cache@v2
+              uses: actions/cache@v5
               with:
                   path: ~/build
                   key: build-lazyfs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,6 @@
 name: build
 on: 
+  workflow_dispatch:
   push:
     paths:
       - 'lazyfs/**'


### PR DESCRIPTION
Hi,

This PR fixes the `build` workflow by updating the action versions:

```yaml
uses: actions/checkout@v6
uses: actions/cache@v5
```

It also enables manual triggering of the `build` workflow:

```yaml
on:
  workflow_dispatch:
```

Future notes:

GitHub's Ubuntu Latest is 24.04, which still uses `libfuse3-3`.
The next version of Ubuntu, and Debian latest, update to `libfuse3-4`.
Using `lazyfs` with Debian latest and `libfuse3-4` seems to work fine.

You can see the progression of commits and their ultimate success in the [forked repository's actions](https://github.com/nurturenature/lazyfs/actions).
