### PR TITLE
increase MAX_READ_CHUNK from 100 to 255 to support more realistic path/command lengths

### DIFF
--- a/lazyfs/src/main.cpp
+++ b/lazyfs/src/main.cpp
@@ -22,7 +22,7 @@
 
 using namespace lazyfs;
 
-#define MAX_READ_CHUNK 100
+#define MAX_READ_CHUNK 255
 
 cache::config::Config std_config;
 std::thread faults_handler_thread;


### PR DESCRIPTION
Hi,

I was testing possibly adding `torn-seq` and `torn-op` to Jepsen's `jepsen.lazyfs` Nemesis, and noticed that longer file paths were breaking command parsing:

<pre>
[global] [info] [lazyfs.fifo]: running LazyFS...
[global] [info] [lazyfs.faults.worker]: waiting for fault commands...
[global] [info] [lazyfs.faults.worker]: received 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/config.toml::persist=[2]::occurr'
[global] [info] [lazyfs.faults.worker]: configured successfully 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/config.toml::persist=[2]::occurr'
[global] [info] [lazyfs.faults.worker]: command unknown 'nce=1'
[global] [info] [lazyfs.faults.worker]: received 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/control-db/conf::persist=[2]::oc'
[global] [info] [lazyfs.faults.worker]: configured successfully 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/control-db/conf::persist=[2]::oc'
[global] [info] [lazyfs.faults.worker]: command unknown 'urrence=1'
...
</pre>

This PR increases `MAX_READ_CHUNK` from 100 to 255.
As any fixed # will be arbitrary, this seemed both adequate and reasonable.

After increasing `MAX_READ_CHUNK`, the build and tests continue to pass.
Rerunning the Jepsen tests shows successful command parsing:

<pre>
[global] [info] [lazyfs.fifo]: running LazyFS...
[global] [info] [lazyfs.faults.worker]: waiting for fault commands...
[global] [info] [lazyfs.faults.worker]: received 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/config.toml::persist=[2]::occurrence=1'
[global] [info] [lazyfs.faults.worker]: configured successfully 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/config.toml::persist=[2]::occurrence=1'
[global] [info] [lazyfs.faults.worker]: received 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/control-db/conf::persist=[2]::occurrence=1'
[global] [info] [lazyfs.faults.worker]: configured successfully 'lazyfs::torn-seq::op=write::file=/root/.local/share/spacetime/data/control-db/conf::persist=[2]::occurrence=1'
...
</pre>

and a `torn-seq` that was enough to unrecoverably crash the system being tested:

<img width="900" height="400" alt="torn-seq-latency-raw" src="https://github.com/user-attachments/assets/c3dfac67-e82d-4f08-a958-9cd0df05b0d1" />

----

If you are willing to accept this PR, would you also be willing to create a new tag/release?

If so, I will work on adding `torn-seq` and `torn-op` support to Jepsen's `jepsen.lazyfs` Nemesis.

Also note that the current latest tag, `0.3.0`, doesn't include the `torn-seq` and `torn-op` [refactor](https://github.com/dsrhaslab/lazyfs/commit/229debd28d9764334792efd66f8c42050beee98c), etc.

Thanks!
